### PR TITLE
New feature, remove all

### DIFF
--- a/ToDoList.py
+++ b/ToDoList.py
@@ -96,6 +96,16 @@ remove_all_button.Bind(wx.EVT_BUTTON, remove_all_tasks)
 list_title = wx.StaticText(panel, label="Tasks")
 task_list = wx.ListBox(panel, style=wx.LB_SINGLE | wx.LB_ALWAYS_SB)
 
+#Set shortcuts.
+accelerator_entries = [
+(wx.ACCEL_ALT, ord("A"), add_button.GetId()),
+(wx.ACCEL_ALT, ord("F"), complete_button.GetId()),
+(wx.ACCEL_ALT, ord("D"), remove_button.GetId()),
+(wx.ACCEL_ALT, ord("R"), remove_all_button.GetId())
+]
+accelerator_table = wx.AcceleratorTable(accelerator_entries)
+frame.SetAcceleratorTable(accelerator_table)
+
 # Load tasks initially
 update_list()
 
@@ -105,10 +115,11 @@ sizer.Add(task_entry, 0, wx.EXPAND | wx.ALL, 5)
 sizer.Add(add_button, 0, wx.ALL, 5)
 sizer.Add(complete_button, 0, wx.ALL, 5)
 sizer.Add(remove_button, 0, wx.ALL, 5)
+sizer.Add(remove_all_button, 0, wx.ALL, 5)
 sizer.Add(list_title, 0, wx.LEFT | wx.TOP, 5)
 sizer.Add(task_list, 1, wx.EXPAND | wx.ALL, 5)
 
 panel.SetSizer(sizer)
 
-frame.Show()
+frame.Show(True)
 app.MainLoop()

--- a/ToDoList.py
+++ b/ToDoList.py
@@ -1,5 +1,6 @@
 import wx
 import json
+import os
 
 # Function to add a task to the to-do list
 def add_task(event):
@@ -41,10 +42,25 @@ def remove_task(event):
 	else:
 		wx.MessageBox("No task selected.", "Error", wx.OK | wx.ICON_ERROR)
 
+# Function to remove all.
+def remove_all_tasks(event):
+	if len( todo_list) <1:
+		wx.MessageBox("No task to remove.", "Error", wx.OK | wx.ICON_ERROR)
+	else:
+		totallen=len(todo_list)
+		todo_list.clear()
+		update_list()
+		save_tasks()
+		wx.MessageBox(f"{totallen} task{"s" if totallen >1 else ""} removed successfully!", "Success", wx.OK | wx.ICON_INFORMATION)
+
 # Function to save tasks to JSON file
 def save_tasks():
-	with open("tasks.json", "w") as file:
-		json.dump(todo_list, file)
+	if len(todo_list)<1:
+		os.remove("tasks.json")
+	else:
+
+		with open("tasks.json", "w") as file:
+			json.dump(todo_list, file)
 
 # Function to load tasks from JSON file
 def load_tasks():
@@ -73,6 +89,9 @@ complete_button.Bind(wx.EVT_BUTTON, complete_task)
 
 remove_button = wx.Button(panel, label="Remove Task")
 remove_button.Bind(wx.EVT_BUTTON, remove_task)
+
+remove_all_button = wx.Button(panel, label="Remove all Tasks")
+remove_all_button.Bind(wx.EVT_BUTTON, remove_all_tasks)
 
 list_title = wx.StaticText(panel, label="Tasks")
 task_list = wx.ListBox(panel, style=wx.LB_SINGLE | wx.LB_ALWAYS_SB)

--- a/ToDoList.py
+++ b/ToDoList.py
@@ -13,6 +13,7 @@ def add_task(event):
 		wx.MessageBox("Task added successfully!", "Success", wx.OK | wx.ICON_INFORMATION)
 	else:
 		wx.MessageBox("Please enter a task.", "Error", wx.OK | wx.ICON_ERROR)
+	task_entry.SetFocus()
 
 # Function to mark a task as completed
 def complete_task(event):
@@ -22,8 +23,10 @@ def complete_task(event):
 		update_list()
 		save_tasks()
 		wx.MessageBox("Task marked as completed!", "Success", wx.OK | wx.ICON_INFORMATION)
+		task_list.SetFocus()
 	else:
 		wx.MessageBox("No task selected.", "Error", wx.OK | wx.ICON_ERROR)
+		task_list.SetFocus()
 
 # Function to view the to-do list
 def update_list():
@@ -41,6 +44,7 @@ def remove_task(event):
 		wx.MessageBox(f"Task '{removed_task}' removed successfully!", "Success", wx.OK | wx.ICON_INFORMATION)
 	else:
 		wx.MessageBox("No task selected.", "Error", wx.OK | wx.ICON_ERROR)
+	task_list.SetFocus()
 
 # Function to remove all.
 def remove_all_tasks(event):
@@ -52,6 +56,7 @@ def remove_all_tasks(event):
 		update_list()
 		save_tasks()
 		wx.MessageBox(f"{totallen} task{"s" if totallen >1 else ""} removed successfully!", "Success", wx.OK | wx.ICON_INFORMATION)
+	task_list.SetFocus()
 
 # Function to save tasks to JSON file
 def save_tasks():

--- a/ToDoList.py
+++ b/ToDoList.py
@@ -1,6 +1,7 @@
 import wx
 import json
 import os
+import sys
 
 # Function to add a task to the to-do list
 def add_task(event):
@@ -83,33 +84,26 @@ frame = wx.Frame(None, title="To-Do List Manager", size=(400, 400))
 
 panel = wx.Panel(frame)
 
-task_label = wx.StaticText(panel, label="Enter Task:")
+task_label = wx.StaticText(panel, label="Enter &Task:")
 task_entry = wx.TextCtrl(panel, style=wx.TE_MULTILINE)
 
-add_button = wx.Button(panel, label="Add Task")
+add_button = wx.Button(panel, label="&Add Task")
 add_button.Bind(wx.EVT_BUTTON, add_task)
 
-complete_button = wx.Button(panel, label="Mark Task as Completed")
+complete_button = wx.Button(panel, label="Mark Task as &Completed")
 complete_button.Bind(wx.EVT_BUTTON, complete_task)
 
-remove_button = wx.Button(panel, label="Remove Task")
+remove_button = wx.Button(panel, label="Remove T&ask")
 remove_button.Bind(wx.EVT_BUTTON, remove_task)
 
-remove_all_button = wx.Button(panel, label="Remove all Tasks")
+remove_all_button = wx.Button(panel, label="&Remove all Tasks")
 remove_all_button.Bind(wx.EVT_BUTTON, remove_all_tasks)
 
-list_title = wx.StaticText(panel, label="Tasks")
+list_title = wx.StaticText(panel, label="&List of Tasks")
 task_list = wx.ListBox(panel, style=wx.LB_SINGLE | wx.LB_ALWAYS_SB)
 
-#Set shortcuts.
-accelerator_entries = [
-(wx.ACCEL_ALT, ord("A"), add_button.GetId()),
-(wx.ACCEL_ALT, ord("F"), complete_button.GetId()),
-(wx.ACCEL_ALT, ord("D"), remove_button.GetId()),
-(wx.ACCEL_ALT, ord("R"), remove_all_button.GetId())
-]
-accelerator_table = wx.AcceleratorTable(accelerator_entries)
-frame.SetAcceleratorTable(accelerator_table)
+quitbutton=wx.Button(panel, label="&Exit")
+quitbutton.Bind(wx.EVT_BUTTON, sys.exit)
 
 # Load tasks initially
 update_list()
@@ -123,6 +117,7 @@ sizer.Add(remove_button, 0, wx.ALL, 5)
 sizer.Add(remove_all_button, 0, wx.ALL, 5)
 sizer.Add(list_title, 0, wx.LEFT | wx.TOP, 5)
 sizer.Add(task_list, 1, wx.EXPAND | wx.ALL, 5)
+sizer.Add(quitbutton, 0, wx.ALL, 5)
 
 panel.SetSizer(sizer)
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ A simple tool that allows you to save your to-do list. For example, you can save
 
 ### Features
 
-* simple with GUI dialogs.
+* Simple with GUI dialogs.
 * Automatically saves your to-do list.
 
 ### Feedback

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 wxpython
+json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 wxpython
-json


### PR DESCRIPTION
Added a new feature called remove all, which removes all tasks.

Now, If the tasks list has less than 1 elements, the save function will delete the `tasks.json` file.

Added shortcuts.

Alt+A, add button.

Alt+F, complete button.

Alt+D, remove button.

Alt+R, remove all button.

The shortcut keys are spoken as because using the keyword `&`