### PR TITLE
Shortcut conflict fixes

### DIFF
--- a/ToDoList.py
+++ b/ToDoList.py
@@ -86,11 +86,11 @@ def load_tasks():
 
 # Main program
 app = wx.App()
-frame = wx.Frame(None, title="To-Do List Manager", size=(400, 400))
+frame = wx.Frame(None, title="To-Do List Manager", size=(600, 400))
 
 panel = wx.Panel(frame)
 
-task_label = wx.StaticText(panel, label="Enter &Task:")
+task_label = wx.StaticText(panel, label="&Enter Task:")
 task_entry = wx.TextCtrl(panel, style=wx.TE_MULTILINE)
 
 add_button = wx.Button(panel, label="&Add Task")
@@ -99,13 +99,13 @@ add_button.Bind(wx.EVT_BUTTON, add_task)
 complete_button = wx.Button(panel, label="Mark Task as &Completed")
 complete_button.Bind(wx.EVT_BUTTON, complete_task)
 
-remove_button = wx.Button(panel, label="Remove T&ask")
+remove_button = wx.Button(panel, label="&Remove Task")
 remove_button.Bind(wx.EVT_BUTTON, remove_task)
 
-remove_all_button = wx.Button(panel, label="&Remove all Tasks")
+remove_all_button = wx.Button(panel, label="&Delete all Tasks")
 remove_all_button.Bind(wx.EVT_BUTTON, remove_all_tasks)
 
-exit_button=wx.Button(panel,label="&exit")
+exit_button=wx.Button(panel,label="e&xit")
 exit_button.Bind(wx.EVT_BUTTON, sys.exit)
 
 list_title = wx.StaticText(panel, label="&List of Tasks")

--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,8 @@
 # To-Do-List tool, changes
 
+## Sunday, April 21, 2024
+* Fixed shortcut conflicts. Remove all button is now rename to delete all, and shortcut is alt+d. Enter task text edit box is alt+e, remove a task button is alt+r, and exit button is alt+x.
+
 ## Wednesday, April 10, 2024
 * Added the check to completion of tasks. From now on, trying to mark as completed upon the task that is already marked as completed will end up failure, displaying error message.
 * Added `compile.bat` file into the directory, allowing to compile into executable to be distributed.


### PR DESCRIPTION
Fixed shortcut conflicts. Remove all button is now rename to delete all, and shortcut is alt+d. Enter task text edit box is alt+e, remove a task button is alt+r, and exit button is alt+x.